### PR TITLE
Using secrets in integration tests issue resolved

### DIFF
--- a/BackEnd/Swintake.Integration.tests/TestStartUp.cs
+++ b/BackEnd/Swintake.Integration.tests/TestStartUp.cs
@@ -30,13 +30,5 @@ namespace Swintake.Integration.tests
             services.AddMvc()
                 .AddApplicationPart(typeof(Startup).Assembly);
         }
-
-        protected override void ConfigureSwintake(IApplicationBuilder app, IHostingEnvironment env)
-        {
-            base.ConfigureSwintake(app, env);
-            var builder = new ConfigurationBuilder();
-            builder.AddUserSecrets<TestStartup>();
-            builder.Build();
-        }
     }
 }

--- a/BackEnd/Swintake.Integration.tests/Users/UsersIntegrationTests.cs
+++ b/BackEnd/Swintake.Integration.tests/Users/UsersIntegrationTests.cs
@@ -1,76 +1,61 @@
-﻿//using Microsoft.AspNetCore.Hosting;
-//using Microsoft.AspNetCore.TestHost;
-//using Microsoft.EntityFrameworkCore;
-//using Microsoft.Extensions.Configuration;
-//using Microsoft.Extensions.DependencyInjection;
-//using Newtonsoft.Json;
-//using Swintake.api.Helpers.Users;
-//using Swintake.domain.Data;
-//using Swintake.domain.Users;
-//using System;
-//using System.Net.Http;
-//using System.Text;
-//using System.Threading.Tasks;
-//using Xunit;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Swintake.api.Helpers.Users;
+using Swintake.domain.Data;
+using Swintake.domain.Users;
+using Swintake.services.Users.Security;
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
 
-//namespace Swintake.Integration.tests
-//{
-//    public class UsersIntegrationTests
-//    {
-//        private static DbContextOptions<SwintakeContext> CreateNewInMemoryDatabase()
-//        {
-//            return new DbContextOptionsBuilder<SwintakeContext>()
-//                .UseInMemoryDatabase("swintake" + Guid.NewGuid().ToString("n"))
-//                .Options;
-//        }
+namespace Swintake.Integration.tests
+{
+    public class UsersIntegrationTests
+    {
 
-//        IConfiguration Configuration { get; set; }
+        [Fact]
+        public async Task GivenExistingUser_WhenAuthenticate_ThenReturnOkWithJwtSecurityTokenRawData()
+        {
+            var server = new TestServer(new WebHostBuilder()
+                .UseStartup<TestStartup>()
+                .UseConfiguration(new ConfigurationBuilder()
+                    .AddUserSecrets("ecafb124-3b88-4041-ac3d-6bf9172b7efa")
+                    .Build()));
 
-//        public UsersIntegrationTests()
-//        {
-//            // the type specified here is just so the secrets library can 
-//            // find the UserSecretId we added in the csproj file
-//            var builder = new ConfigurationBuilder()
-//                .AddUserSecrets<UsersIntegrationTests>();
+            using (server)
+            {
+                var client = server.CreateClient();
 
-//            Configuration = builder.Build();
-//        }
+                var context = server.Host.Services.GetService<SwintakeContext>();
 
-//        [Fact]
-//        public async Task GivenExistingUser_WhenAuthenticate_ThenReturnOkWithJwtSecurityTokenRawData()
-//        {
-//            var server = new TestServer(new WebHostBuilder().UseStartup<TestStartup>());
+                var user = new UserBuilder()
+                        .WithEmail("user@switchfully.com")
+                        .WithFirstName("User")
+                        .WithUserSecurity(new UserSecurity("WO8nNwTcrxigARQfBn4nYRh8X16ExDQJ8jNuECJT8fE=", "F1e3n6zNR75LhUd5K73T/g=="))
+                        .Build();
 
-//            using (server)
-//            {
-//                var username = Configuration["ApiUsername"];
-//                var password = Configuration["ApiPassword"];
+                context.Users.Add(user);
+                context.SaveChanges();
 
-//                var 
-//                var client = server.CreateClient();
+                var userDTO = new UserDTO { Email = "user@switchfully.com", Password = "ILoveNiels" };
 
-//                var context = server.Host.Services.GetService<SwintakeContext>();
+                var content = JsonConvert.SerializeObject(userDTO);
+                var stringContent = new StringContent(content, Encoding.UTF8, "application/json");
 
-//                var user = new UserBuilder()
-//                        .WithEmail("user@switchfully.com")
-//                        .WithFirstName("User")
-//                        .WithUserSecurity(new UserSecurity("WO8nNwTcrxigARQfBn4nYRh8X16ExDQJ8jNuECJT8fE=", "F1e3n6zNR75LhUd5K73T/g=="))
-//                        .Build();
+                var response = await client.PostAsync("api/users/authenticate", stringContent);
+                var responseString = await response.Content.ReadAsStringAsync();
 
-//                context.Users.Add(user);
-//                context.SaveChanges();
+                // The returned token is of format plain/text not of json.
+                // var test = JsonConvert.DeserializeObject(responseString);
 
-//                var userDTO = new UserDTO { Email = "user@switchfully.com", Password = "ILoveNiels" };
-
-//                var content = JsonConvert.SerializeObject(userDTO);
-//                var stringContent = new StringContent(content, Encoding.UTF8, "application/json");
-
-//                var response = await client.PostAsync("api/users/authenticate", stringContent);
-//                var responseString = await response.Content.ReadAsStringAsync();
-//                var test = JsonConvert.DeserializeObject(responseString);
-
-//                Assert.True(response.IsSuccessStatusCode);
-//            }
-//        }
-//    }
-//}
+                Assert.True(response.IsSuccessStatusCode);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Cleaned up `TestStartup`
- Configured `UsersIntegrationTests` to load-in the secret with the corresponding `UserSecretsId` (https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-2.1&tabs=windows#set-a-secret and (https://weblog.west-wind.com/posts/2018/Feb/18/Accessing-Configuration-in-NET-Core-Test-Projects)
