### PR TITLE
removing redundant comments + added a refactoring TODO

### DIFF
--- a/BackEnd/Swintake/Controllers/CampaignsController.cs
+++ b/BackEnd/Swintake/Controllers/CampaignsController.cs
@@ -39,26 +39,16 @@ namespace Swintake.api.Controllers
         [Authorize]
         public ActionResult<IEnumerable<CampaignDto>> GetAllCampaigns()
         {
-            //var allCompaigns = _campaignService.GetCampaigns()
-            //    .Select(campaign => _campaignMapper.ToDto(campaign));
-            //return ok(allCompaigns.ToList());
-
-            //service gets domain items
-
             IEnumerable<Campaign> campaigns = _campaignService.GetAllCampaigns();
 
-            //from domain to dto
+            // TODO: THIS (MAP MULTIPLE DTOS) CAN BE PLACED INSIDE OF THE CAMPAIGNMAPPER
             List<CampaignDto> campaignDtos = new List<CampaignDto>();
-
             foreach (Campaign campaign in campaigns)
             {
-                //convert each campaign to dto
                 CampaignDto campaignDto = _campaignMapper.ToDto(campaign);
-                //add to to list
                 campaignDtos.Add(campaignDto);
             }
 
-            //return dto result
             return Ok(campaignDtos);
         }
 
@@ -76,18 +66,6 @@ namespace Swintake.api.Controllers
 
             return Ok(campaignToReturn);
         }
-
-        // PUT: api/Campaign/5
-        //[HttpPut("{id}")]
-        //public void Put(int id, [FromBody] string value)
-        //{
-        //}
-
-        // DELETE: api/ApiWithActions/5
-        //[HttpDelete("{id}")]
-        //public void Delete(int id)
-        //{
-        //}
 
     }
 }


### PR DESCRIPTION
1. Comments verwijderd. Commentaar (Comments) is een code smell (documentatie daarom niet), zeker als ze geen meerwaarde bieden.
2. Code die in commentaar stond is verwijderd (met version control systemen kunnen we deze nadien terughalen mochten we dat willen. Methodes / Code in commentaar zetten noemen we daarom ook wel eens de 'pussy delete')
3. Een TODO toegevoegd: de foreach loop meerdere dto's gaat mappen kan perfect naar een methode getrokken worden die dan in de mapper zelf wordt gestoken.